### PR TITLE
Add .gitattributes file to fix Windows pulling and dev containers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
By default windows will pull with CRLF file endings - which causes a problem when trying to run the `stageEnv.sh` file in the rockylinux container

Setting a `.gitattributes` file will force LF file endings so the dev container can run the script just fine :)